### PR TITLE
Feature: log output to file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,19 +6,20 @@ const redsink = require('./lib/redsink.js')
 const pkg = require('./package.json')
 
 program.name(pkg.name)
-program.version(pkg.version)
-program.arguments('[source_host] [dest_host]')
-program.option('-d, --debug', 'Enable debug mode')
-program.option('--hot-sync', 'Enable hot syncing')
-program.option('--from <source_host>', 'Source host')
-program.option('--from-token <token>', 'Source host AUTH token')
-program.option('--from-user <user>', 'Source host user name')
-program.option('--from-password <password>', 'Source host user password')
-program.option('--to <dest_host>', 'Dest host')
-program.option('--to-token <token>', 'Dest host AUTH token')
-program.option('--to-user <user>', 'Dest host user name')
-program.option('--to-password <password>', 'Dest host user password')
-program.parse(process.argv)
+  .version(pkg.version)
+  .arguments('[source_host] [dest_host]')
+  .option('-d, --debug', 'Enable debug mode')
+  .option('-o, --output [filename]', 'Output log messages to file (default: redsink.log)')
+  .option('--hot-sync', 'Enable hot syncing')
+  .option('--from <source_host>', 'Source host')
+  .option('--from-token <token>', 'Source host AUTH token')
+  .option('--from-user <user>', 'Source host user name')
+  .option('--from-password <password>', 'Source host user password')
+  .option('--to <dest_host>', 'Dest host')
+  .option('--to-token <token>', 'Dest host AUTH token')
+  .option('--to-user <user>', 'Dest host user name')
+  .option('--to-password <password>', 'Dest host user password')
+  .parse(process.argv)
 
 const [sourceHost, destHost] = program.args
 const options = program.opts()
@@ -32,11 +33,16 @@ const config = {
   dest_auth_user: options.toUser,
   dest_auth_password: options.toPassword,
   debug: options.debug,
-  hotSync: options.hotSync
+  hotSync: options.hotSync,
+  output: options.output
 }
 
-if (options.debug) {
+if (config.debug) {
   console.debug(chalk.green('main:'), JSON.stringify(config))
+}
+
+if (config.output === true) {
+  config.output = 'redsink.log'
 }
 
 redsink(config)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,5 @@
 const readline = require('readline')
+const fs = require('fs')
 const chalk = require('chalk')
 
 function getColour (level) {
@@ -16,8 +17,32 @@ function getColour (level) {
   }
 }
 
+let logFile
+
+function openLogfile (filename = 'redsink.log') {
+  logFile = fs.createWriteStream(filename)
+  writeToLogfile('Output log started')
+}
+
+function writeToLogfile (message) {
+  if (!logFile) {
+    return
+  }
+
+  logFile.write(new Date().toLocaleString() + ' => ' + message + '\n')
+}
+
+function closeLogfile () {
+  if (!logFile) {
+    return
+  }
+
+  logFile.end()
+}
+
 function logger (prefix, options = {}) {
   const logger = {}
+
   for (const x of ['debug', 'info', 'warn', 'error', 'log', 'time', 'timeEnd']) {
     const colouredPrefix = chalk[getColour(x)](prefix + ':')
     logger[x] = (...passedArgs) => {
@@ -28,20 +53,25 @@ function logger (prefix, options = {}) {
         logger._inlining = false
       }
       console[x].apply(null, args)
+      writeToLogfile(args.join())
     }
   }
+
   if (!options.debug) {
     logger.debug = () => {}
   }
+
   logger.inline = (text) => {
     logger._inlining = true
     const colouredPrefix = chalk.white(prefix + ':')
     readline.cursorTo(process.stdout, 0)
     process.stdout.write(colouredPrefix + ' ' + text)
   }
+
   return logger
 }
 
 module.exports = logger
-
 module.exports.main = logger('main')
+module.exports.openLogfile = openLogfile
+module.exports.closeLogfile = closeLogfile

--- a/lib/redsink.js
+++ b/lib/redsink.js
@@ -3,6 +3,10 @@ const connect = require('./connect.js')
 const logger = require('./logger.js')
 
 function redsink (config) {
+  if (config.output) {
+    logger.openLogfile(config.output)
+  }
+
   logger.main.time('Total run time')
   const { source, monitor, dest } = connect(config)
   const scanner = new Scanner(source.client, source.logger, {
@@ -52,6 +56,7 @@ function redsink (config) {
     return (value) => {
       handle(value)
       logger.main.timeEnd('Total run time')
+      logger.closeLogfile()
       process.exit(0)
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redsink",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redsink",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redsink",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "cli.js",
   "bin": {
     "redsink": "./cli.js"

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,5 @@
-const { promisify } = require('util')
 const path = require('path')
-const { setTimeout: sleep } = require('timers/promises')
+const { async, readFile, rm, sleep } = require('./helpers.js')
 const assert = require('assert')
 const redis = require('redis')
 const { GenericContainer } = require('testcontainers')
@@ -12,10 +11,6 @@ function startRedis (name) {
     .withName(name)
     .withExposedPorts(6379)
     .start()
-}
-
-function async (object, methodName) {
-  return promisify(object[methodName]).bind(object)
 }
 
 async function populate (client, namespace, count) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -205,4 +205,27 @@ describe('redsink (integration)', function () {
     assert.equal(sourceDbSize, DATA_SIZE + 100000)
     assert.equal(destDbSize, DATA_SIZE + 100000)
   })
+
+  it('output a log file once the migration has finished', async function () {
+    after(async function () {
+      // Remove log file
+      // await rm('redsink.log')
+    })
+
+    this.timeout(10000)
+
+    await async(this.sourceClient, 'DBSIZE')()
+    await async(this.destClient, 'DBSIZE')()
+
+    const { sourcePort, sourceHost, destPort, destHost } = this
+    await cmd.execute(pathToCli, [
+      '--output',
+      `--from=${sourceHost}:${sourcePort}`,
+      `--to=${destHost}:${destPort}`
+    ])
+    await sleep(3000)
+
+    const data = await readFile('redsink.log')
+    assert.ok(data, 'File does not exist')
+  })
 })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,18 @@
+const { promisify } = require('util')
+const fs = require('fs/promises')
+const { setTimeout: sleep } = require('timers/promises')
+
+exports.async = function async (object, methodName) {
+  return promisify(object[methodName]).bind(object)
+}
+
+exports.sleep = sleep
+
+exports.rm = async function rm (filepath) {
+  await fs.rm(filepath)
+}
+
+exports.readFile = async function readFile (file) {
+  const data = await fs.readFile(file, 'utf8')
+  return data
+}

--- a/test/lib/logger.test.js
+++ b/test/lib/logger.test.js
@@ -1,4 +1,6 @@
+const assert = require('assert')
 const sinon = require('sinon')
+const { readFile, rm, sleep } = require('../helpers.js')
 const logger = require('../../lib/logger.js')
 
 describe('logger', function () {
@@ -30,6 +32,38 @@ describe('logger', function () {
     it('should log in debug mode', function () {
       logger('debug', { debug: true }).debug('this is a debug log')
       sinon.assert.calledWith(console.debug, '\x1B[90mdebug:\x1B[39m this is a debug log')
+    })
+  })
+
+  describe('logfile', function () {
+    it('should create a redsink.log file by default', async function () {
+      after(async function () {
+        // Remove log file
+        await rm('redsink.log')
+      })
+
+      logger.openLogfile()
+      logger('logfile').info('logger test!')
+      logger.closeLogfile()
+      await sleep(25)
+
+      const data = await readFile('redsink.log')
+      assert.ok(data, 'File does not exist')
+    })
+
+    it('should create a custom log file', async function () {
+      after(async function () {
+        // Remove log file
+        await rm('custom.log')
+      })
+
+      logger.openLogfile('custom.log')
+      logger('logfile').info('logger test!')
+      logger.closeLogfile()
+      await sleep(25)
+
+      const data = await readFile('custom.log')
+      assert.ok(data, 'File does not exist')
     })
   })
 })


### PR DESCRIPTION
Simple feature I built as an exercise along with an acquaintance. The general idea is to have it so that the logs of the migration can easily output to a file asynchronously. 

One would argue that you could just redirect (>) the output of `stdout`, which I would agree you could do. However, to avoid potential issues with the inline progress logging, creating a separate file stream seemed safest.